### PR TITLE
Verify grafana-pcp RMP works with rhel-edge

### DIFF
--- a/check-ostree.yaml
+++ b/check-ostree.yaml
@@ -798,6 +798,20 @@
             failed_counter: "{{ failed_counter | int + 1 }}"
       when: result_rollback is succeeded
 
+    # case: check if grafana-pcp is installed
+    - name: grafana-pcp should be installed
+      block:
+        - name: grafana-pcp should be installed
+          shell: rpm -q grafana-pcp
+          register: result_grafana_pcp_packages
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+
     - assert:
         that:
           - failed_counter == "0"

--- a/ostree.sh
+++ b/ostree.sh
@@ -334,6 +334,13 @@ version = "*"
 EOF
 fi
 
+# Ensure grafana-pcp is in the base blueprint
+tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[packages]]
+name = "grafana-pcp"
+version = "*"
+EOF
+
 # Fedora does not support user configuration in blueprint for fedora-iot-commit image
 if [[ "${USER_IN_COMMIT}" == "true" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
@@ -463,6 +470,10 @@ done
 # Check image installation result
 check_result
 
+# Check whether grafana-pcp RPM is installed
+sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${GUEST_ADDRESS}" \
+    'rpm -q grafana-pcp'
+
 ##################################################
 ##
 ## ostree image/commit upgrade
@@ -500,6 +511,13 @@ name = "sssd"
 version = "*"
 EOF
 fi
+
+# Ensure grafana-pcp is in the upgrade blueprint
+tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[packages]]
+name = "grafana-pcp"
+version = "*"
+EOF
 
 # RHEL 8.7 and 9.1 later support embeded container in commit
 if [[ "${EMBEDDED_CONTAINER}" == "true" ]]; then


### PR DESCRIPTION
Extend  rhel-edge test suite with a grafana-pcp tests, so it is ensured that grafana-pcp is installed on the final image.